### PR TITLE
Maybe fix sneasel/snorunt checks. Are they even broken?

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -4489,81 +4489,69 @@ bool8 IsSneaselInParty(void)
     {
     u8 i;
     u8 partyCount = CalculatePlayerPartyCount();
-    
+
     for (i = 0; i < partyCount; i++)
     {
         if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNEASEL)
         {
-            
             s32 level = GetMonData(&gPlayerParty[i], MON_DATA_LEVEL, NULL);
             if (level > 29)
-            {
                 return TRUE;
-            } 
         }
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNEASEL)
-        {
+        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_WEAVILE)
             return TRUE;
-        }
     }
     return FALSE;
     }
 
 bool8 IsSnoruntInParty(void)
-    {
+{
     u8 i;
     u8 partyCount = CalculatePlayerPartyCount();
-    
+
     for (i = 0; i < partyCount; i++)
     {
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNORUNT)
-        {
+        if (
+          GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNORUNT
+            || GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_GLALIE
+            || GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_FROSLASS
+        )
             return TRUE;
-        }
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_GLALIE)
-        {
-            return TRUE;
-        }
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNORUNT)
-        {
-            return TRUE;
-        }
     }
     return FALSE;
     }
 
+// Returns true if the player has no sneasel/weavile
+// OR if the player has it, but it doesn’t have the champion ribbon.
 bool8 IsSneaselTrainedNotChampion(void)
-    {
+{
     u8 i;
     u8 partyCount = CalculatePlayerPartyCount();
-    
+
     for (i = 0; i < partyCount; i++)
     {
         if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNEASEL)
         {
-            
             s32 level = GetMonData(&gPlayerParty[i], MON_DATA_LEVEL, NULL);
             if (level > 49 )
             {
                 bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
                 if (ribbon == 0)
-                return FALSE;
-            } 
+                    return FALSE;
+            }
         }
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNEASEL)
+        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_WEAVILE)
         {
-            {
-                bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
-                if (ribbon == 0)
+            bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
+            if (ribbon == 0)
                 return FALSE;
-            } 
         }
     }
     return TRUE;
-    }
+}
 
 bool8 IsSnoruntTrainedNotChampion(void)
-    {
+{
     u8 i;
     u8 partyCount = CalculatePlayerPartyCount();
     
@@ -4582,26 +4570,22 @@ bool8 IsSnoruntTrainedNotChampion(void)
         }
         if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_GLALIE)
         {
-            {
-                bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
-                if (ribbon == 0)
+            bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
+            if (ribbon == 0)
                 return FALSE;
-            } 
         }
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNORUNT)
+        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_FROSLASS)
         {
-            {
-                bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
-                if (ribbon == 0)
+            bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
+            if (ribbon == 0)
                 return FALSE;
-            } 
         }
     }
     return TRUE;
-    }
+}
 
 bool8 DoesDawnSneaselHaveChampionRibbon(void)
-    {
+{
     u8 i;
     u8 partyCount = CalculatePlayerPartyCount();
     
@@ -4626,7 +4610,7 @@ bool8 DoesDawnSneaselHaveChampionRibbon(void)
         }
     }
     return FALSE;
-    }
+}
 
 bool8 DoesBrendanSnoruntHaveChampionRibbon(void)
     {
@@ -4637,7 +4621,6 @@ bool8 DoesBrendanSnoruntHaveChampionRibbon(void)
     {
         if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNORUNT)
         {
-            
             bool8 ribbon = GetMonData(&gPlayerParty[i], MON_DATA_CHAMPION_RIBBON, NULL);
             if (ribbon == 1)
             {
@@ -4665,56 +4648,53 @@ bool8 DoesBrendanSnoruntHaveChampionRibbon(void)
     }
 
 void RyuKillMon(void)
-    {
-            u8 i;
-            u8 partyCount = CalculatePlayerPartyCount();
+{
+    u8 i;
+    u8 partyCount = CalculatePlayerPartyCount();
 
-            for (i = 0; i < partyCount; i++)
-            {
-                if (GetMonData(&gPlayerParty[i], MON_DATA_HP) == 0)
-                {
-                    ZeroMonData(&gPlayerParty[i]);
-                    CompactPartySlots();
-                    PlaySE(SE_POKE_DEAD);
-                }
-            }
+    for (i = 0; i < partyCount; i++)
+    {
+        if (GetMonData(&gPlayerParty[i], MON_DATA_HP) == 0)
+        {
+            ZeroMonData(&gPlayerParty[i]);
+            CompactPartySlots();
+            PlaySE(SE_POKE_DEAD);
+        }
     }
+}
 
 bool8 RyuSacrificeMon(void)
-    {
-        u8 slot = (VarGet(VAR_TEMP_9));
-        u16 species = 0;
-        u16 move1 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE1);
-        u16 move2 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE2);
-        u16 move3 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE3);
-        u16 move4 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE4);
-        u8 ability = GetMonData(&gPlayerParty[slot], MON_DATA_ABILITY_NUM);
+{
+    u8 slot = (VarGet(VAR_TEMP_9));
+    u16 species = 0;
+    u16 move1 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE1);
+    u16 move2 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE2);
+    u16 move3 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE3);
+    u16 move4 = GetMonData(&gPlayerParty[slot], MON_DATA_MOVE4);
+    u8 ability = GetMonData(&gPlayerParty[slot], MON_DATA_ABILITY_NUM);
 
-        if (FlagGet(FLAG_TEMP_5) == 1)
-        {
-            species = (GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES2, NULL));
-            ZeroMonData(&gPlayerParty[slot]);
-            CompactPartySlots();
-            VarSet(VAR_RYU_GCMS_SPECIES, species);
-            VarSet(VAR_RYU_GCMS_MOVE1, move1);
-            VarSet(VAR_RYU_GCMS_MOVE2, move2);
-            VarSet(VAR_RYU_GCMS_MOVE3, move3);
-            VarSet(VAR_RYU_GCMS_MOVE4, move4);
-            VarSet(VAR_RYU_GCMS_ABILITY, ability);
-            FlagClear(FLAG_TEMP_5);
-            return TRUE;
-        }
-        else if (GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES2, NULL) == (VarGet(VAR_RYU_GCMS_SPECIES)))
-        {
-            ZeroMonData(&gPlayerParty[slot]);
-            CompactPartySlots();
-            return TRUE;
-        }
-        else
-        {
-            return FALSE;
-        }
+    if (FlagGet(FLAG_TEMP_5) == 1)
+    {
+        species = (GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES2, NULL));
+        ZeroMonData(&gPlayerParty[slot]);
+        CompactPartySlots();
+        VarSet(VAR_RYU_GCMS_SPECIES, species);
+        VarSet(VAR_RYU_GCMS_MOVE1, move1);
+        VarSet(VAR_RYU_GCMS_MOVE2, move2);
+        VarSet(VAR_RYU_GCMS_MOVE3, move3);
+        VarSet(VAR_RYU_GCMS_MOVE4, move4);
+        VarSet(VAR_RYU_GCMS_ABILITY, ability);
+        FlagClear(FLAG_TEMP_5);
+        return TRUE;
     }
+    else if (GetMonData(&gPlayerParty[slot], MON_DATA_SPECIES2, NULL) == (VarGet(VAR_RYU_GCMS_SPECIES)))
+    {
+        ZeroMonData(&gPlayerParty[slot]);
+        CompactPartySlots();
+        return TRUE;
+    }
+    return FALSE;
+}
 
 void RyuWipeParty(void)
 {
@@ -4727,6 +4707,7 @@ void RyuWipeParty(void)
     CompactPartySlots();
 }
 
+// Should more accurately be called “Player has Weavile but no Sneasel”
 bool8 IsSneaselWeavile(void)
 {
     u8 i;
@@ -4734,17 +4715,12 @@ bool8 IsSneaselWeavile(void)
     u8 flag = (FlagGet(FLAG_RYU_DAWN_GIFTPOKE_RECEIVED));
     if (flag == 1)
     {
-    
         for (i = 0; i < partyCount; i++)
         {
             if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNEASEL)
-            {
-                    return FALSE;
-            }
-            if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_SNEASEL)
-            {
-                    return TRUE;
-            }
+                return FALSE;
+            if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES2, NULL) == SPECIES_WEAVILE)
+                return TRUE;
         }
     }
     return FALSE;
@@ -4800,9 +4776,7 @@ void RyuBrendanGiftPoke(void)
 void RyuDevCheck(void)
 {
     if (FlagGet(FLAG_RYU_DEV_MODE) == 1)
-    {
-            gSpecialVar_Result = 69;
-    }
+        gSpecialVar_Result = 69;
 }
 
 void checkbadgecount(void)


### PR DESCRIPTION
No idea how these were supposed to work, but I’m not sure they ever did, so I’d appreciate some input here.
As it stands, most of these checks are redundant in some way, e.g. IsSneaselInParty first checks if there is a sneasel above level 29 but then checks again if there is a sneasel of any level. What’s the idea there? I figured maybe you wanted to check for weavile instead but made a copy paste error, but all of the checks are like that.

What was the intention here? Even if this PR isn’t correct, some documentation on those functions would be nice so the next person isn’t as confused as I was.